### PR TITLE
Fix custom card type declaration

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -14,6 +14,17 @@ Custom Lovelace card für Home Assistant, die die Laufzeiten von Proxmox-Knoten,
 4. Nach dem Hinzufügen kannst du die Card in HACS suchen und installieren.
 5. Die Ressource `proxmox-uptime-card.js` wird automatisch eingebunden und steht anschließend in Lovelace zur Verfügung.
 
+## Verwendung
+
+Füge die Karte deinem Dashboard hinzu, indem du sie im YAML-Modus bearbeitest oder im visuellen Editor **Code-Editor anzeigen** auswählst. Verwende `custom:proxmox-uptime-card` als Kartentyp:
+
+```yaml
+type: custom:proxmox-uptime-card
+title: Proxmox Uptime
+entities:
+  - sensor.proxmox_host_uptime
+```
+
 ## Entwicklung
 
 Die Card wird ohne zusätzliche UI-Frameworks implementiert und über `defineCustomElement` als `proxmox-uptime-card` registriert.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Custom Lovelace card for Home Assistant that visualises the uptime of Proxmox no
 4. After adding it, search for the card in HACS and install it.
 5. The `proxmox-uptime-card.js` resource is added automatically and becomes available in Lovelace.
 
+## Usage
+
+Add the card to your dashboard by editing it in YAML mode or using the visual editor's **Show code editor** option. Use `custom:proxmox-uptime-card` as the card type:
+
+```yaml
+type: custom:proxmox-uptime-card
+title: Proxmox Uptime
+entities:
+  - sensor.proxmox_host_uptime
+```
+
 ## Attribution
 
 Portions of this project are derived from the [Home Assistant History Graph Card](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-history-graph-card.ts),

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -58,7 +58,7 @@ class ProxmoxUptimeCard extends LitElement {
 
   static getStubConfig() {
     return {
-      type: "proxmox-uptime-card",
+      type: "custom:proxmox-uptime-card",
       entities: [ "sensor.proxmox_host_uptime" ],
     };
   }
@@ -436,9 +436,9 @@ if (!customElements.get("proxmox-uptime-card-editor")) {
 }
 
 window.customCards = window.customCards || [];
-if (!window.customCards.some((card) => card.type === "proxmox-uptime-card")) {
+if (!window.customCards.some((card) => card.type === "custom:proxmox-uptime-card")) {
   window.customCards.push({
-    type: "proxmox-uptime-card",
+    type: "custom:proxmox-uptime-card",
     name: "Proxmox Uptime Card",
     preview: true,
     description: "Visualises uptime sensors from the Proxmox integration.",
@@ -446,7 +446,7 @@ if (!window.customCards.some((card) => card.type === "proxmox-uptime-card")) {
 }
 
 export const ProxmoxUptimeCardDefinition = {
-  type: "proxmox-uptime-card",
+  type: "custom:proxmox-uptime-card",
   name: "Proxmox Uptime Card",
   description: "Visualises uptime sensors from the Proxmox integration.",
   async loadCardHelpers() {
@@ -460,7 +460,7 @@ export const ProxmoxUptimeCardDefinition = {
   },
   getStubConfig() {
     return {
-      type: "proxmox-uptime-card",
+      type: "custom:proxmox-uptime-card",
       entities: [ "sensor.proxmox_host_uptime" ],
     };
   },


### PR DESCRIPTION
## Summary
- ensure the stub configs and card registry use the custom:proxmox-uptime-card type prefix so Lovelace recognises the card
- document how to configure the card in both English and German READMEs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e00480ad7c832e9f4d15a13d9b3898