### PR TITLE
feat: show sensor icons above timelines

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -25,6 +25,20 @@ entities:
   - sensor.proxmox_host_uptime
 ```
 
+### Anzeigenamen und Icons
+
+Passe die Beschriftung und das Icon pro Sensor im visuellen Editor oder per YAML an:
+
+```yaml
+type: custom:proxmox-uptime-card
+names:
+  binary_sensor.node_alpha_status: Proxmox Node Alpha
+icons:
+  binary_sensor.node_alpha_status: mdi:server
+```
+
+Die Sensorbezeichnung erscheint oberhalb des Zeitstrahls, links daneben steht das gewählte Icon.
+
 ## Entwicklung
 
 Die Card kapselt die bestehende History-Graph-Implementierung aus Home Assistant und reicht die relevanten Optionen automatisiert weiter.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ entities:
   - sensor.proxmox_host_uptime
 ```
 
+### Friendly names and icons
+
+Override the displayed label and icon per sensor either via the visual editor or YAML:
+
+```yaml
+type: custom:proxmox-uptime-card
+names:
+  binary_sensor.node_alpha_status: Proxmox Node Alpha
+icons:
+  binary_sensor.node_alpha_status: mdi:server
+```
+
+Sensor names are shown above each timeline with the configured icon on the left.
+
 ## Attribution
 
 This project wraps the upstream [Home Assistant History Graph Card](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-history-graph-card.ts) and forwards its configuration so that uptime sensors are displayed without additional manual setup.

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2377,6 +2377,7 @@ const applyTimelineLabelsToTimelines = (timelines, options) => {
     const availableHeight = Math.max(0, totalHeight - gridTop - gridBottom);
     const rowCount = data.length;
     const rowSpan = rowCount ? availableHeight / rowCount : 0;
+    const barHeight = 20;
     const labelGap = 6;
 
     const labels = data
@@ -2394,8 +2395,10 @@ const applyTimelineLabelsToTimelines = (timelines, options) => {
           prettifyEntityId(entityId);
         const icon =
           entityInfo?.icon || hassState?.attributes?.icon || "mdi:server";
-        const rowTop = gridTop + rowSpan * index;
-        const top = Math.max(0, rowTop - labelGap);
+        const rowCenter = gridTop + rowSpan * index + rowSpan / 2;
+        const barOffset = Math.min(rowSpan / 2, barHeight / 2);
+        const baseline = rowCenter - barOffset - labelGap;
+        const top = Math.max(0, baseline);
         return { entityId, name, icon, top };
       })
       .filter(Boolean);

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2120,6 +2120,7 @@ const createTimelineLabelOverlay = (container) => {
   overlay.style.pointerEvents = "none";
   overlay.style.display = "block";
   overlay.style.zIndex = "2";
+  overlay.style.overflow = "visible";
   container.appendChild(overlay);
   return overlay;
 };
@@ -2158,6 +2159,14 @@ const applyTimelineLabelsToTimelines = (timelines, options) => {
       container.style.position = "relative";
     }
 
+    if (container.style.overflow !== "visible") {
+      container.style.overflow = "visible";
+    }
+
+    if (chartBase && chartBase.style.overflow !== "visible") {
+      chartBase.style.overflow = "visible";
+    }
+
     if (!showNames) {
       if (timeline[TIMELINE_LABEL_SIGNATURE_KEY]) {
         const overlay = container.querySelector(
@@ -2183,7 +2192,6 @@ const applyTimelineLabelsToTimelines = (timelines, options) => {
     const availableHeight = Math.max(0, totalHeight - gridTop - gridBottom);
     const rowCount = data.length;
     const rowSpan = rowCount ? availableHeight / rowCount : 0;
-    const barHeight = 20;
     const labelGap = 6;
 
     const labels = data
@@ -2201,8 +2209,8 @@ const applyTimelineLabelsToTimelines = (timelines, options) => {
           prettifyEntityId(entityId);
         const icon =
           entityInfo?.icon || hassState?.attributes?.icon || "mdi:server";
-        const centerY = gridTop + rowSpan * index + rowSpan / 2;
-        const top = Math.max(0, centerY - barHeight / 2 - labelGap);
+        const rowTop = gridTop + rowSpan * index;
+        const top = Math.max(0, rowTop - labelGap);
         return { entityId, name, icon, top };
       })
       .filter(Boolean);
@@ -2248,6 +2256,7 @@ const applyTimelineLabelsToTimelines = (timelines, options) => {
       labelElement.style.pointerEvents = "auto";
       labelElement.style.cursor = "pointer";
       labelElement.style.lineHeight = "1.4";
+      labelElement.style.transform = "translateY(-100%)";
 
       const iconEl = document.createElement("ha-icon");
       iconEl.setAttribute("icon", label.icon);


### PR DESCRIPTION
## Summary
- move sensor labels above each uptime timeline and render entity icons alongside them
- allow overriding icons via the visual editor and YAML by adding icon parsing/serialization
- document the new name and icon overrides in both English and German READMEs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e25e136580832ea26426423868b70d