### PR TITLE
Add custom icons and reposition timeline labels

### DIFF
--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2365,27 +2365,26 @@ if (!customElements.get("proxmox-uptime-card")) {
           align-items: stretch;
         }
 
-        .proxmox-timeline-row {
-          display: flex;
-          flex-direction: column;
-          align-items: stretch;
-        }
-
         .proxmox-timeline-inline-label {
           display: flex;
           align-items: center;
           gap: 10px;
-          margin: 6px 0 2px;
+          margin: 8px 0 4px;
           color: var(--primary-text-color);
           font-weight: 500;
           font-size: 0.95rem;
           line-height: 1.2;
           pointer-events: none;
+          grid-column: 1 / -1;
         }
 
         .proxmox-timeline-inline-label ha-icon {
           --mdc-icon-size: 20px;
           color: var(--primary-text-color);
+        }
+
+        .proxmox-timeline-row {
+          display: contents;
         }
       `;
       styleRoot.append(style);

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2438,15 +2438,20 @@ if (!customElements.get("proxmox-uptime-card")) {
         });
 
         const signature = JSON.stringify({ data: signaturePayload });
-        if (timelineEl.dataset.proxmoxLayoutSignature === signature) {
+        const existingLabels = timelineRoot.querySelectorAll(
+          ".proxmox-timeline-inline-label"
+        );
+        const labelsArePresent = existingLabels.length >= timelineRows.length;
+        if (
+          timelineEl.dataset.proxmoxLayoutSignature === signature &&
+          labelsArePresent
+        ) {
           return;
         }
 
         timelineEl.dataset.proxmoxLayoutSignature = signature;
 
-        timelineRoot
-          .querySelectorAll(".proxmox-timeline-inline-label")
-          .forEach((label) => label.remove());
+        existingLabels.forEach((label) => label.remove());
 
         timelineRows.forEach((rowEl, index) => {
           const parent = rowEl?.parentElement;

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2320,30 +2320,35 @@ if (!customElements.get("proxmox-uptime-card")) {
       const style = document.createElement("style");
       style.setAttribute("data-proxmox-timeline-layout", "true");
       style.textContent = `
-        .proxmox-timeline-container {
-          position: relative;
-        }
-
         .proxmox-timeline-label-overlay {
-          position: absolute;
-          inset: 0;
           display: flex;
           flex-direction: column;
-          justify-content: flex-start;
+          align-items: flex-start;
+          gap: 6px;
+          margin-bottom: 8px;
           pointer-events: none;
-          z-index: 2;
+          width: 100%;
+        }
+
+        .proxmox-timeline-container {
+          display: flex;
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .proxmox-timeline-container > state-history-chart-timeline {
+          display: flex;
+          flex-direction: column;
         }
 
         .proxmox-timeline-label-row {
           display: flex;
-          align-items: flex-start;
-          gap: 8px;
+          align-items: center;
+          gap: 10px;
           color: var(--primary-text-color);
           font-weight: 500;
           font-size: 0.95rem;
           line-height: 1.2;
-          padding-bottom: 12px;
-          box-sizing: border-box;
         }
 
         .proxmox-timeline-label-row:last-child {
@@ -2406,14 +2411,15 @@ if (!customElements.get("proxmox-uptime-card")) {
         if (!overlay) {
           overlay = document.createElement("div");
           overlay.className = "proxmox-timeline-label-overlay";
-          container.appendChild(overlay);
+          container.insertBefore(overlay, timelineEl);
+        } else if (overlay.nextSibling !== timelineEl) {
+          container.insertBefore(overlay, timelineEl);
         }
 
         const chartBase =
           timelineEl.shadowRoot?.querySelector("ha-chart-base") ||
           timelineEl.querySelector?.("ha-chart-base");
         const timelineHeight = chartBase?.offsetHeight || timelineEl.offsetHeight || 0;
-        const rowHeight = timelineHeight && data.length ? timelineHeight / data.length : 0;
 
         const signaturePayload = data.map((entry) => {
           const entityId = entry?.entity_id || entry?.id || "";
@@ -2443,12 +2449,6 @@ if (!customElements.get("proxmox-uptime-card")) {
         signaturePayload.forEach((entryInfo) => {
           const row = document.createElement("div");
           row.className = "proxmox-timeline-label-row";
-          if (rowHeight) {
-            const spacing = Math.max(12, Math.round(rowHeight * 0.35));
-            const usableHeight = Math.max(0, rowHeight - spacing);
-            row.style.height = `${usableHeight}px`;
-            row.style.paddingBottom = `${spacing}px`;
-          }
 
           const iconEl = document.createElement("ha-icon");
           iconEl.setAttribute("icon", entryInfo.icon || "mdi:server-network");

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2311,6 +2311,28 @@ if (!customElements.get("proxmox-uptime-card")) {
             labels.forEach((label) => label.remove());
             removed = true;
           }
+          const rowContainers = timelineRoot.querySelectorAll(
+            ".proxmox-timeline-row"
+          );
+          rowContainers.forEach((rowContainer) => {
+            const host = rowContainer.parentElement;
+            if (!host) {
+              return;
+            }
+            Array.from(rowContainer.childNodes).forEach((child) => {
+              if (
+                child.nodeType === Node.ELEMENT_NODE &&
+                child.classList?.contains("proxmox-timeline-inline-label")
+              ) {
+                child.remove();
+                removed = true;
+              } else {
+                host.insertBefore(child, rowContainer);
+                removed = true;
+              }
+            });
+            rowContainer.remove();
+          });
           removeLayoutStyle(timelineRoot);
         }
 
@@ -2338,6 +2360,12 @@ if (!customElements.get("proxmox-uptime-card")) {
       style.setAttribute("data-proxmox-timeline-layout", "true");
       style.textContent = `
         .proxmox-timeline-container {
+          display: flex;
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .proxmox-timeline-row {
           display: flex;
           flex-direction: column;
           align-items: stretch;
@@ -2458,6 +2486,22 @@ if (!customElements.get("proxmox-uptime-card")) {
           if (!parent) {
             return;
           }
+          let rowContainer;
+          if (parent.classList?.contains("proxmox-timeline-row")) {
+            rowContainer = parent;
+          } else {
+            rowContainer = document.createElement("div");
+            rowContainer.className = "proxmox-timeline-row";
+            parent.insertBefore(rowContainer, rowEl);
+            rowContainer.append(rowEl);
+          }
+
+          Array.from(
+            rowContainer.querySelectorAll(
+              ":scope > .proxmox-timeline-inline-label"
+            )
+          ).forEach((label) => label.remove());
+
           const entryInfo = signaturePayload[index] || {};
           const labelRow = document.createElement("div");
           labelRow.className = "proxmox-timeline-inline-label";
@@ -2470,7 +2514,7 @@ if (!customElements.get("proxmox-uptime-card")) {
           textEl.textContent = entryInfo.name || entryInfo.id || "";
           labelRow.append(textEl);
 
-          parent.insertBefore(labelRow, rowEl);
+          rowContainer.insertBefore(labelRow, rowEl);
         });
 
         applied = true;

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2337,22 +2337,32 @@ if (!customElements.get("proxmox-uptime-card")) {
       style.setAttribute("data-proxmox-timeline-layout", "true");
       style.textContent = `
         .proxmox-timeline-inline-label {
-          display: inline-flex;
+          display: flex;
           align-items: center;
           gap: 10px;
+          grid-column: 1 / -1;
           color: var(
-            --proxmox-label-accent,
-            var(--primary-text-color, var(--secondary-text-color, currentColor))
+            --primary-text-color,
+            var(--secondary-text-color, currentColor)
           );
           font-weight: 500;
-          font-size: 0.95rem;
-          line-height: 1.2;
-          padding-inline: 2px;
-          margin-block: 10px 4px;
+          font-size: var(--mdc-typography-body1-font-size, 0.95rem);
+          line-height: 1.4;
+          padding-inline: 4px;
+          margin-block: 10px 2px;
+          opacity: 1;
+          visibility: visible;
+          border-inline-start: 3px solid
+            var(--proxmox-label-accent, transparent);
+          padding-inline-start: calc(4px + 2px);
         }
 
         .proxmox-timeline-inline-label:first-child {
           margin-block-start: 0;
+        }
+
+        .proxmox-timeline-inline-label + ha-timeline {
+          margin-block-start: 4px;
         }
 
         ha-timeline + .proxmox-timeline-inline-label {
@@ -2363,8 +2373,16 @@ if (!customElements.get("proxmox-uptime-card")) {
           --mdc-icon-size: 20px;
           color: var(
             --proxmox-label-accent,
-            var(--primary-text-color, var(--secondary-text-color, currentColor))
+            var(--state-on-color, currentColor)
           );
+        }
+
+        .proxmox-timeline-inline-label span {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          flex: 1 1 auto;
+          min-width: 0;
         }
       `;
       styleRoot.append(style);

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -2363,28 +2363,30 @@ if (!customElements.get("proxmox-uptime-card")) {
           display: flex;
           flex-direction: column;
           align-items: stretch;
+          gap: 6px;
+        }
+
+        .proxmox-timeline-row {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          width: 100%;
         }
 
         .proxmox-timeline-inline-label {
-          display: flex;
+          display: inline-flex;
           align-items: center;
           gap: 10px;
-          margin: 8px 0 4px;
-          color: var(--primary-text-color);
+          color: var(--primary-text-color, inherit);
           font-weight: 500;
           font-size: 0.95rem;
           line-height: 1.2;
-          pointer-events: none;
-          grid-column: 1 / -1;
+          padding-inline: 2px;
         }
 
         .proxmox-timeline-inline-label ha-icon {
           --mdc-icon-size: 20px;
-          color: var(--primary-text-color);
-        }
-
-        .proxmox-timeline-row {
-          display: contents;
+          color: var(--primary-text-color, inherit);
         }
       `;
       styleRoot.append(style);


### PR DESCRIPTION
## Summary
- allow configuring sensor icons through the visual editor and persist them in card config
- include configured icons when building entity definitions for the history timeline
- render sensor names with icons above each timeline row and hide the default left-aligned labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26d99fd14832e97ee4dbbdf499863