### PR TITLE
Add configuration toggle to hide timeline

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -25,6 +25,10 @@ entities:
   - sensor.proxmox_host_uptime
 ```
 
+### Optionen
+
+- `show_timeline` *(optional, Standard `true`)* – Auf `false` setzen, um den unteren Zeitstrahl auszublenden. Die Option ist ebenfalls im visuellen Editor unter **Darstellung** verfügbar.
+
 ## Entwicklung
 
 Die Card kapselt die bestehende History-Graph-Implementierung aus Home Assistant und reicht die relevanten Optionen automatisiert weiter.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ entities:
   - sensor.proxmox_host_uptime
 ```
 
+### Options
+
+- `show_timeline` *(optional, default `true`)* – Set to `false` to hide the lower timeline graph. The toggle is also available in the visual editor under the **Display** tab.
+
 ## Attribution
 
 This project wraps the upstream [Home Assistant History Graph Card](https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-history-graph-card.ts) and forwards its configuration so that uptime sensors are displayed without additional manual setup.

--- a/proxmox-uptime-card.js
+++ b/proxmox-uptime-card.js
@@ -1,4 +1,4 @@
-const CARD_VERSION = "2.2.0";
+const CARD_VERSION = "2.3.0";
 const DEFAULT_FILTER = [
   "binary_sensor.node_.*_status",
   "binary_sensor.vm_.*_status",
@@ -60,6 +60,7 @@ const ensureEditorElementRegistered = () => {
       fields: [
         "hours_to_show",
         "show_names",
+        "show_timeline",
         "name_filters",
         "timeline_color_on",
         "timeline_color_off",
@@ -84,6 +85,7 @@ const ensureEditorElementRegistered = () => {
         show_all: "Show all entities",
         hours_to_show: "Hours to show",
         show_names: "Show legend names",
+        show_timeline: "Show timeline",
         name_filters: "Name filters",
         timeline_color_on: "Timeline color (on)",
         timeline_color_off: "Timeline color (off)",
@@ -99,6 +101,7 @@ const ensureEditorElementRegistered = () => {
         show_all: "Alle Entitäten anzeigen",
         hours_to_show: "Anzuzeigende Stunden",
         show_names: "Legendenamen anzeigen",
+        show_timeline: "Zeitstrahl anzeigen",
         name_filters: "Namensfilter",
         timeline_color_on: "Zeitstrahlfarbe (an)",
         timeline_color_off: "Zeitstrahlfarbe (aus)",
@@ -136,6 +139,8 @@ const ensureEditorElementRegistered = () => {
         names_raw: "Use 'entity_id = Friendly Name' per line to override names.",
         show_all:
           "Remove the Proxmox integration filter when picking binary sensors.",
+        show_timeline:
+          "Toggle visibility of the timeline displayed at the bottom of the card.",
         name_filters:
           "Provide words or phrases (one per line) to strip from entity names.",
         timeline_color_on: "Color applied when a sensor reports ON (uptime).",
@@ -153,6 +158,8 @@ const ensureEditorElementRegistered = () => {
           "'entity_id = Anzeigename' pro Zeile für Namensüberschreibungen.",
         show_all:
           "Entfernt den Proxmox-Filter bei der Auswahl von Binary-Sensoren.",
+        show_timeline:
+          "Steuert die Sichtbarkeit des unten angezeigten Zeitstrahls.",
         name_filters:
           "Wörter oder Phrasen (eine pro Zeile), die aus den Namen entfernt werden sollen.",
         timeline_color_on: "Farbe, wenn der Sensor AN meldet (Uptime).",
@@ -247,6 +254,7 @@ const ensureEditorElementRegistered = () => {
     names_raw: () => ({ name: "names_raw", selector: { text: { multiline: true } } }),
     hours_to_show: () => ({ name: "hours_to_show", selector: { number: { min: 1 } } }),
     show_names: () => ({ name: "show_names", selector: { boolean: {} } }),
+    show_timeline: () => ({ name: "show_timeline", selector: { boolean: {} } }),
     name_filters: () => ({ name: "name_filters", selector: { text: { multiline: true } } }),
     show_all: () => ({ name: "show_all", selector: { boolean: {} } }),
     timeline_color_on: () => null,
@@ -368,6 +376,7 @@ const ensureEditorElementRegistered = () => {
     "name_filters",
     "hours_to_show",
     "show_names",
+    "show_timeline",
     "language",
     "timeline_color_on",
     "timeline_color_off",
@@ -458,6 +467,7 @@ const ensureEditorElementRegistered = () => {
         show_all: config.show_all || false,
         hours_to_show: config.hours_to_show,
         show_names: config.show_names ?? true,
+        show_timeline: config.show_timeline !== false,
         name_filters: serializePatternList(config.name_filters),
         timeline_color_on: config.timeline_color_on || "",
         timeline_color_off: config.timeline_color_off || "",
@@ -908,6 +918,10 @@ const ensureEditorElementRegistered = () => {
         config.show_names = form.show_names;
       }
 
+      if (form.show_timeline !== undefined) {
+        config.show_timeline = form.show_timeline;
+      }
+
       const nameFilters = parseNameFilters(form.name_filters);
       if (nameFilters) {
         config.name_filters = nameFilters;
@@ -1253,6 +1267,7 @@ const TIMELINE_ORIGINAL_COLORS_KEY = "__proxmoxTimelineOriginalColors";
 const TIMELINE_SIGNATURE_KEY = "__proxmoxTimelineSignature";
 const TIMELINE_ORIGINAL_STYLE_KEY = "__proxmoxTimelineOriginalStyles";
 const TIMELINE_ELEMENT_SIGNATURE_KEY = "__proxmoxTimelineElementSignature";
+const TIMELINE_VISIBILITY_KEY = "__proxmoxTimelineVisibility";
 
 const COLOR_FIELDS = [
   { name: "timeline_color_on" },
@@ -1885,6 +1900,45 @@ const buildTimelineDynamicStyleTargets = (timeline) => {
   };
 };
 
+const applyTimelineVisibility = (elements, showTimeline) => {
+  if (!elements?.length) {
+    return false;
+  }
+
+  let found = false;
+  elements.forEach((timeline) => {
+    if (!timeline) {
+      return;
+    }
+    found = true;
+    if (showTimeline) {
+      const original = timeline[TIMELINE_VISIBILITY_KEY];
+      const originalDisplay = original ? original.display : undefined;
+      if (original) {
+        if (originalDisplay) {
+          timeline.style.setProperty("display", originalDisplay);
+        } else {
+          timeline.style.removeProperty("display");
+        }
+        delete timeline[TIMELINE_VISIBILITY_KEY];
+      } else if (timeline.style.getPropertyValue("display") === "none") {
+        timeline.style.removeProperty("display");
+      }
+    } else {
+      if (!timeline[TIMELINE_VISIBILITY_KEY]) {
+        timeline[TIMELINE_VISIBILITY_KEY] = {
+          display: timeline.style.getPropertyValue("display"),
+        };
+      }
+      if (timeline.style.getPropertyValue("display") !== "none") {
+        timeline.style.setProperty("display", "none");
+      }
+    }
+  });
+
+  return found;
+};
+
 const applyTimelineColorsToTimelines = (elements, config) => {
   if (!elements?.length || !config) {
     return false;
@@ -2244,6 +2298,7 @@ if (!customElements.get("proxmox-uptime-card")) {
       this._lastEntitiesKey = "";
       this._timelineColorTimeout = undefined;
       this._lastTimelineSignature = "";
+      this._timelineVisibilityTimeout = undefined;
     }
 
     static getStubConfig() {
@@ -2297,12 +2352,14 @@ if (!customElements.get("proxmox-uptime-card")) {
 
       if (this._card) {
         this._card.hass = hass;
+        this._scheduleTimelineVisibilityUpdate();
         this._scheduleTimelineColorUpdate();
       }
     }
 
     disconnectedCallback() {
       this._clearTimelineColorTimeout();
+      this._clearTimelineVisibilityTimeout();
     }
 
     getCardSize() {
@@ -2317,6 +2374,13 @@ if (!customElements.get("proxmox-uptime-card")) {
       if (this._timelineColorTimeout) {
         clearTimeout(this._timelineColorTimeout);
         this._timelineColorTimeout = undefined;
+      }
+    }
+
+    _clearTimelineVisibilityTimeout() {
+      if (this._timelineVisibilityTimeout) {
+        clearTimeout(this._timelineVisibilityTimeout);
+        this._timelineVisibilityTimeout = undefined;
       }
     }
 
@@ -2426,6 +2490,41 @@ if (!customElements.get("proxmox-uptime-card")) {
         changed = true;
       }
       return changed;
+    }
+
+    _scheduleTimelineVisibilityUpdate() {
+      const showTimeline = this._config?.show_timeline !== false;
+      this._clearTimelineVisibilityTimeout();
+      let attempts = 0;
+      const attemptLimit = 20;
+
+      const apply = () => {
+        if (!this.isConnected || !this._card) {
+          this._timelineVisibilityTimeout = undefined;
+          return;
+        }
+        const applied = this._applyTimelineVisibilityToCard(showTimeline);
+        if (!applied && attempts < attemptLimit) {
+          attempts += 1;
+          this._timelineVisibilityTimeout = setTimeout(apply, 150);
+        } else {
+          this._timelineVisibilityTimeout = undefined;
+        }
+      };
+
+      apply();
+    }
+
+    _applyTimelineVisibilityToCard(showTimeline) {
+      if (!this._card) {
+        return false;
+      }
+      const timelineElements = collectTimelineElements(this._card);
+      if (!timelineElements.length) {
+        return false;
+      }
+      applyTimelineVisibility(timelineElements, showTimeline);
+      return true;
     }
 
     _scheduleTimelineColorUpdate() {
@@ -2584,6 +2683,7 @@ if (!customElements.get("proxmox-uptime-card")) {
       cardElement.hass = this._hass;
       this._card = cardElement;
       this.append(cardElement);
+      this._scheduleTimelineVisibilityUpdate();
       this._scheduleTimelineColorUpdate();
     }
 
@@ -2607,6 +2707,7 @@ if (!customElements.get("proxmox-uptime-card")) {
       }
       this._card = undefined;
       this._clearTimelineColorTimeout();
+      this._clearTimelineVisibilityTimeout();
       this._lastTimelineSignature = "";
     }
   }


### PR DESCRIPTION
## Summary
- add a `show_timeline` option with editor support to toggle the bottom timeline
- hide timeline elements in the rendered card when the new option is disabled and bump the card version
- document the new configuration in both the English and German READMEs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e285687958832eb790b9185882c27e